### PR TITLE
PORT MODULE: DUMP GFF3

### DIFF
--- a/modules/ensembl/gff3/dumpgff3/environment.yml
+++ b/modules/ensembl/gff3/dumpgff3/environment.yml
@@ -8,4 +8,4 @@ dependencies:
   - python=3.10
   - pip
   - pip:
-    - ensembl-genomio>1.5.0
+    - ensembl-genomio=1.6.0

--- a/modules/ensembl/gff3/dumpgff3/environment.yml
+++ b/modules/ensembl/gff3/dumpgff3/environment.yml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+name: "gff3_dumpgff3"
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - python=3.10
+  - pip
+  - pip:
+    - ensembl-genomio>1.5.0

--- a/modules/ensembl/gff3/dumpgff3/environment.yml
+++ b/modules/ensembl/gff3/dumpgff3/environment.yml
@@ -1,5 +1,3 @@
----
-# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
 name: "gff3_dumpgff3"
 channels:
   - conda-forge

--- a/modules/ensembl/gff3/dumpgff3/main.nf
+++ b/modules/ensembl/gff3/dumpgff3/main.nf
@@ -16,7 +16,7 @@
 process GFF3_DUMPGFF3 {
     tag "${db.species}"
     label 'process_low'
-    // maxForks "${params.max_database_forks}"
+    maxForks 10
     
     container 'ensemblorg/ensembl-legacy-scripts:e112_APIv0.4'
 
@@ -49,7 +49,9 @@ process GFF3_DUMPGFF3 {
         gt gff3validator ${output}
         rm ${temp_gff}
 
-        echo -e -n "${task.process}:\n\tensembl-genomio: ${version}" > versions.yml
+        echo -e -n "${task.process}:\n\tgt gff3validator: " > versions.yml
+        gt gff3validator -version | head -n 1 | cut -f4 -d ' ' >> versions.yml
+        echo -e -n "${task.process}:\n\tensembl-legacy-scripts: ${version}\n" >> versions.yml
         """
 
     stub:
@@ -59,6 +61,8 @@ process GFF3_DUMPGFF3 {
         """
         cp ${input_gff3} ${output_stub}
 
-        echo -e -n "${task.process}:\n\tensembl-genomio: ${version}" > versions.yml
+        echo -e -n "${task.process}:\n\tgt gff3validator: " > versions.yml
+        gt gff3validator -version | head -n 1 | cut -f4 -d ' ' >> versions.yml
+        echo -e -n "${task.process}:\n\tensembl-legacy-scripts: ${version}\n" >> versions.yml
         """
 }

--- a/modules/ensembl/gff3/dumpgff3/main.nf
+++ b/modules/ensembl/gff3/dumpgff3/main.nf
@@ -1,0 +1,65 @@
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+process GFF3_DUMPGFF3 {
+    tag "${db.species}"
+    label 'process_low'
+    // maxForks "${params.max_database_forks}"
+    
+    conda "${moduleDir}/environment.yml"
+    container 'ensemblorg/ensembl-legacy-scripts:e112_APIv0.4'
+
+    input:
+        val db
+
+    output:
+        tuple val(db), val("gff3"), path("*.gff3"), emit: gff3
+        path "versions.yml", emit: versions
+
+    when:
+        task.ext.when == null || task.ext.when
+
+    script:
+        def version = "0.4"
+        output = "${db.species}.gff3"
+        temp_gff = "temp.gff3"
+        password_arg = db.server.password ? "--pass ${db.server.password}" : ""
+        """
+        dump_gff3.pl \
+            --host ${db.server.host} \
+            --port ${db.server.port} \
+            --user ${db.server.user} \
+            ${password_arg} \
+            --dbname ${db.server.database} \
+            > ${temp_gff}
+
+        # Tidy up
+        gt gff3 -tidy -sort -retainids ${temp_gff} > ${output}
+        gt gff3validator ${output}
+        rm ${temp_gff}
+
+        echo -e -n "${task.process}:\n\tensembl-genomio: ${version}" > versions.yml
+        """
+
+    stub:
+        def version = "0.4"
+        def output_stub = "gff_outfile.gff3"
+        def input_gff3 = "${projectDir}/tests/module/ensembl/gff3/dumpgff3/test_dump.gff3"
+        """
+        cp ${input_gff3} ${output_stub}
+
+        echo -e -n "${task.process}:\n\tensembl-genomio: ${version}" > versions.yml
+        """
+}

--- a/modules/ensembl/gff3/dumpgff3/main.nf
+++ b/modules/ensembl/gff3/dumpgff3/main.nf
@@ -18,7 +18,6 @@ process GFF3_DUMPGFF3 {
     label 'process_low'
     // maxForks "${params.max_database_forks}"
     
-    conda "${moduleDir}/environment.yml"
     container 'ensemblorg/ensembl-legacy-scripts:e112_APIv0.4'
 
     input:
@@ -32,7 +31,7 @@ process GFF3_DUMPGFF3 {
         task.ext.when == null || task.ext.when
 
     script:
-        def version = "0.4"
+        version = "0.4"
         output = "${db.species}.gff3"
         temp_gff = "temp.gff3"
         password_arg = db.server.password ? "--pass ${db.server.password}" : ""
@@ -54,9 +53,9 @@ process GFF3_DUMPGFF3 {
         """
 
     stub:
-        def version = "0.4"
-        def output_stub = "gff_outfile.gff3"
-        def input_gff3 = "${projectDir}/tests/module/ensembl/gff3/dumpgff3/test_dump.gff3"
+        version = "0.4"
+        output_stub = "gff_outfile.gff3"
+        input_gff3 = "${projectDir}/tests/module/ensembl/gff3/dumpgff3/test_dump.gff3"
         """
         cp ${input_gff3} ${output_stub}
 

--- a/modules/ensembl/gff3/dumpgff3/meta.yml
+++ b/modules/ensembl/gff3/dumpgff3/meta.yml
@@ -1,5 +1,4 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
 name: "gff3_dumpgff3"
 description: write your description here
 

--- a/modules/ensembl/gff3/dumpgff3/meta.yml
+++ b/modules/ensembl/gff3/dumpgff3/meta.yml
@@ -1,0 +1,42 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "gff3_dumpgff3"
+description: write your description here
+
+keywords:
+  - core_database
+  - python
+  - ensembl-genomio
+  - ensembl-legacy-scripts
+  - fasta
+  - docker
+  - container
+
+tools:
+  - "gff3":
+      homepage: "https://github.com/Ensembl/nextflow_modules"
+      description: "Module which function to dump fasta sequences directly from a core database."
+      licence: ['Apache License version 2.0']
+
+input:
+  - db:
+      type: map
+      description: "A meta map including 'core database name'."
+        e.g. [[ db:'genus_species_gca00000000v1_core_110_1', species:'Genus species', ...]]
+      pattern: "[a-z]+_[a-z]_gc[af][0-9]v[0-9]+_core_*"
+
+output:
+  - gff3:
+      type: map
+      description: "GFF3 file containing gene model(s)."
+        e.g [ db:'database name', file("*.gff3") ]
+      pattern: "*.gff3"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+
+authors:
+  - "@ensembl-dev"
+maintainers:
+  - "@ensembl-dev"

--- a/modules/ensembl/gff3/dumpgff3/meta.yml
+++ b/modules/ensembl/gff3/dumpgff3/meta.yml
@@ -5,8 +5,6 @@ description: write your description here
 
 keywords:
   - core_database
-  - python
-  - ensembl-genomio
   - ensembl-legacy-scripts
   - fasta
   - docker

--- a/modules/ensembl/gff3/dumpgff3/tests/main.nf.test
+++ b/modules/ensembl/gff3/dumpgff3/tests/main.nf.test
@@ -20,8 +20,6 @@ nextflow_process {
     script "../main.nf"
     process "GFF3_DUMPGFF3"
 
-    tag "modules"
-    tag "modules_local"
     tag "gff3"
     tag "gff3/dumpgff3"
 

--- a/modules/ensembl/gff3/dumpgff3/tests/main.nf.test
+++ b/modules/ensembl/gff3/dumpgff3/tests/main.nf.test
@@ -1,0 +1,55 @@
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// nf-core modules test gff3/dumpgff3
+nextflow_process {
+
+    name "Test Process GFF3_DUMPGFF3"
+    script "../main.nf"
+    process "GFF3_DUMPGFF3"
+
+    tag "modules"
+    tag "modules_local"
+    tag "gff3"
+    tag "gff3/dumpgff3"
+
+    test("GFF3 Dump gene models [stub]") {
+
+        when {
+            options "-stub"
+
+                process {
+                    """
+                    input[0] = [[ test_id:'dummy_core_db_core_110_1', species:'Genus species']]
+                    """
+                }
+            }
+
+            then {
+                assert snapshot(
+                    process.out.gff3.collect {
+                        it.collect { it instanceof String && file(it).exists() ? file(it).name : it }
+                        }
+                    ).match("gff3")
+
+            assertAll(
+                    { assert process.success },
+                    { assert snapshot(process.out).match() },
+                    { assert process.out.gff3.size() == 1 },
+                    { assert process.out.gff3 != null }
+            )
+        }
+    }
+}

--- a/modules/ensembl/gff3/dumpgff3/tests/main.nf.test.snap
+++ b/modules/ensembl/gff3/dumpgff3/tests/main.nf.test.snap
@@ -1,0 +1,64 @@
+{
+    "GFF3 Dump gene models [stub]": {
+        "content": [
+            {
+                "0": [
+                    [
+                        [
+                            {
+                                "test_id": "dummy_core_db_core_110_1",
+                                "species": "Genus species"
+                            }
+                        ],
+                        "gff3",
+                        "gff_outfile.gff3:md5,e8261f55873c877206959c86cc91c678"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,f781e978faca3da286270de33f6677a9"
+                ],
+                "gff3": [
+                    [
+                        [
+                            {
+                                "test_id": "dummy_core_db_core_110_1",
+                                "species": "Genus species"
+                            }
+                        ],
+                        "gff3",
+                        "gff_outfile.gff3:md5,e8261f55873c877206959c86cc91c678"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,f781e978faca3da286270de33f6677a9"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.04.3"
+        },
+        "timestamp": "2024-12-16T16:14:41.80428652"
+    },
+    "gff3": {
+        "content": [
+            [
+                [
+                    [
+                        {
+                            "test_id": "dummy_core_db_core_110_1",
+                            "species": "Genus species"
+                        }
+                    ],
+                    "gff3",
+                    "gff_outfile.gff3"
+                ]
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.04.3"
+        },
+        "timestamp": "2024-12-16T16:14:41.678407952"
+    }
+}

--- a/modules/ensembl/gff3/dumpgff3/tests/main.nf.test.snap
+++ b/modules/ensembl/gff3/dumpgff3/tests/main.nf.test.snap
@@ -15,7 +15,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,f781e978faca3da286270de33f6677a9"
+                    "versions.yml:md5,dbfd3136a0ed1ceaeb1bad0387158380"
                 ],
                 "gff3": [
                     [
@@ -30,7 +30,7 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,f781e978faca3da286270de33f6677a9"
+                    "versions.yml:md5,dbfd3136a0ed1ceaeb1bad0387158380"
                 ]
             }
         ],
@@ -38,7 +38,7 @@
             "nf-test": "0.9.2",
             "nextflow": "24.04.3"
         },
-        "timestamp": "2024-12-16T16:14:41.80428652"
+        "timestamp": "2025-02-20T16:12:45.468591866"
     },
     "gff3": {
         "content": [

--- a/modules/ensembl/gff3/dumpgff3/tests/nextflow.config
+++ b/modules/ensembl/gff3/dumpgff3/tests/nextflow.config
@@ -1,3 +1,0 @@
-params {
-    max_database_forks = 1
-}

--- a/modules/ensembl/gff3/dumpgff3/tests/nextflow.config
+++ b/modules/ensembl/gff3/dumpgff3/tests/nextflow.config
@@ -1,0 +1,3 @@
+params {
+    max_database_forks = 1
+}

--- a/modules/ensembl/gff3/dumpgff3/tests/tags.yml
+++ b/modules/ensembl/gff3/dumpgff3/tests/tags.yml
@@ -1,0 +1,2 @@
+gff3/dumpgff3:
+  - "modules/ensembl/gff3/dumpgff3/**"

--- a/tests/module/ensembl/gff3/dumpgff3/test_dump.gff3
+++ b/tests/module/ensembl/gff3/dumpgff3/test_dump.gff3
@@ -1,0 +1,11 @@
+##gff-version 3
+#!gff-spec-version 1.21
+##sequence-region NC_012345.1 1 27754200
+NC_012345.1	RefSeq	region	1	27754200	.	+	.	ID=NC_012345.1:1..27754200;Dbxref=taxon:43211234;Name=LG1;collection-date=2003;country=USA;gbkey=Src;genome=chromosome;isolation-source=field;linkage-group=LG123;mol_type=genomic DNA;sex=male;strain=ABCD;tissue-type=whole body
+NC_012345.1	Gnomon	gene	9273	12174	.	-	.	ID=gene-LOC123FAKE;Dbxref=BEEBASE:GB42195,GeneID:551234;Name=LOC123FAKE;gbkey=Gene;gene=LOC123FAKE;gene_biotype=protein_coding
+NC_012345.1	Gnomon	transcript	9274	12174	.	-	.	ID=rna-XR_000012345.2;Parent=gene-LOC123FAKE;Dbxref=GeneID:551234,Genbank:XR_000012345.2,BEEBASE:GB42195;Name=XR_000012345.2;gbkey=misc_RNA;gene=LOC123FAKE;model_evidence=Supporting evidence includes similarity to RNAseq alignments
+NC_012345.1	Gnomon	exon	11812	12174	.	-	.	ID=exon-XR_000012345.2-1;Parent=rna-XR_000012345.2;Dbxref=GeneID:551234,Genbank:XR_000012345.2,BEEBASE:GB42195;gbkey=misc_RNA;gene=LOC123FAKE;product=ubiquitin-related modifier 1%2C transcript variant X3;transcript_id=XR_000012345.2
+NC_012345.1	Gnomon	exon	11054	11121	.	-	.	ID=exon-XR_000012345.2-2;Parent=rna-XR_000012345.2;Dbxref=GeneID:551234,Genbank:XR_000012345.2,BEEBASE:GB42195;gbkey=misc_RNA;gene=LOC123FAKE;product=ubiquitin-related modifier 1%2C transcript variant X3;transcript_id=XR_000012345.2
+NC_012345.1	Gnomon	exon	10913	10994	.	-	.	ID=exon-XR_000012345.2-3;Parent=rna-XR_000012345.2;Dbxref=GeneID:551234,Genbank:XR_000012345.2,BEEBASE:GB42195;gbkey=misc_RNA;gene=LOC123FAKE;product=ubiquitin-related modifier 1%2C transcript variant X3;transcript_id=XR_000012345.2
+NC_012345.1	Gnomon	exon	9779	9827	.	-	.	ID=exon-XR_000012345.2-4;Parent=rna-XR_000012345.2;Dbxref=GeneID:551234,Genbank:XR_000012345.2,BEEBASE:GB42195;gbkey=misc_RNA;gene=LOC123FAKE;product=ubiquitin-related modifier 1%2C transcript variant X3;transcript_id=XR_000012345.2
+NC_012345.1	Gnomon	exon	9274	9546	.	-	.	ID=exon-XR_000012345.2-5;Parent=rna-XR_000012345.2;Dbxref=GeneID:551234,Genbank:XR_000012345.2,BEEBASE:GB42195;gbkey=misc_RNA;gene=LOC123FAKE;product=ubiquitin-related modifier 1%2C transcript variant X3;transcript_id=XR_000012345.2


### PR DESCRIPTION
The module linked to dumper pipeline, which uses the legacy api container to dump GFF3 files from a core database.