### PR TITLE
Created subworkflow for 'prepare metadata' (now -> metadata/genomesummary)

### DIFF
--- a/modules/ensembl/schema/json/main.nf
+++ b/modules/ensembl/schema/json/main.nf
@@ -32,7 +32,7 @@ process SCHEMA_JSON {
     script:
         schema_name = json_file.simpleName
         """
-        schemas_json_validate --json_file !{json_file} --json_schema !{schema_name}
+        schemas_json_validate --json_file ${json_file} --json_schema ${schema_name}
 
         echo -e -n "${task.process}:\n\tensembl-genomio: " > versions.yml
         schemas_json_validate --version >> versions.yml

--- a/subworkflows/ensembl/prepare_genome_metadata/main.nf
+++ b/subworkflows/ensembl/prepare_genome_metadata/main.nf
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-include { METADATA_GENOMESUMMARY } from '../../../modules/ensembl/metadata/genomesummary/main'
-include { SCHEMA_JSON } from '../../../modules/ensembl/schema/json/main'
+include { METADATA_GENOMESUMMARY } from '../../../modules/ensembl/metadata/genomesummary'
+include { SCHEMA_JSON } from '../../../modules/ensembl/schema/json'
 
 import groovy.json.JsonSlurper
-
 def readJson(json_path) {
     def slurp = new JsonSlurper()
     def json_file = file(json_path)

--- a/subworkflows/ensembl/prepare_genome_metadata/main.nf
+++ b/subworkflows/ensembl/prepare_genome_metadata/main.nf
@@ -68,10 +68,10 @@ workflow PREPARE_GENOME_METADATA {
             .verified_json
             .set { verified_genome_json }
 
-        channel_versions.mix(METADATA_GENOMESUMMARY.versions, SCHEMA_JSON.versions)
+        combined_versions = channel_versions.mix(METADATA_GENOMESUMMARY.out.versions, SCHEMA_JSON.out.versions)
 
     emit:
         prepared_metadata = verified_genome_json // channel: [ val(meta), path(json) ]
-        versions = channel_versions      // channel: [ path(versions.yml), path(versions.yml) ]
+        versions = combined_versions      // channel: [ path(versions.yml), path(versions.yml) ]
 }
 

--- a/subworkflows/ensembl/prepare_genome_metadata/main.nf
+++ b/subworkflows/ensembl/prepare_genome_metadata/main.nf
@@ -71,7 +71,7 @@ workflow PREPARE_GENOME_METADATA {
         combined_versions = channel_versions.mix(METADATA_GENOMESUMMARY.out.versions, SCHEMA_JSON.out.versions)
 
     emit:
-        prepared_metadata = verified_genome_json // channel: [ val(meta), path(json) ]
-        versions = combined_versions      // channel: [ path(versions.yml), path(versions.yml) ]
+        prepared_metadata = verified_genome_json  // channel: [ val(meta), path(json) ]
+        versions = combined_versions  // channel: [ path(versions.yml), path(versions.yml) ]
 }
 

--- a/subworkflows/ensembl/prepare_genome_metadata/main.nf
+++ b/subworkflows/ensembl/prepare_genome_metadata/main.nf
@@ -32,14 +32,11 @@ def metaFromGenomeJson(json_path) {
 
     def prod_name = data.assembly.accession
     def publish_dir = data.assembly.accession
+    def has_annotation = data.annotation.asBoolean()
 
     if ( data.species && data.species.production_name ) {
         prod_name = data.species.production_name
         publish_dir = prod_name
-    }
-    def has_annotation = false
-    if (data.annotation) {
-        has_annotation = true
     }
 
     return [

--- a/subworkflows/ensembl/prepare_genome_metadata/main.nf
+++ b/subworkflows/ensembl/prepare_genome_metadata/main.nf
@@ -1,0 +1,78 @@
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+include { METADATA_GENOMESUMMARY } from '../../../modules/ensembl/metadata/genomesummary/main'
+include { SCHEMA_JSON } from '../../../modules/ensembl/schema/json/main'
+
+import groovy.json.JsonSlurper
+
+def readJson(json_path) {
+    def slurp = new JsonSlurper()
+    def json_file = file(json_path)
+    def text = json_file.text
+    def not_a_lazy_val = slurp.parseText(text)
+    return not_a_lazy_val
+}
+
+// function to create meta tuple from genome.json in the form:
+// tuple("accession": accession, "production_name": production_name, "prefix": prefix)
+def metaFromGenomeJson(json_path) {
+    def data = readJson(json_path)
+
+    def prod_name = data.assembly.accession
+    def publish_dir = data.assembly.accession
+
+    if ( data.species && data.species.production_name ) {
+        prod_name = data.species.production_name
+        publish_dir = prod_name
+    }
+    def has_annotation = false
+    if (data.annotation) {
+        has_annotation = true
+    }
+
+    return [
+        accession: data.assembly.accession,
+        production_name: prod_name,
+        publish_dir: publish_dir,
+        prefix: "",
+        has_annotation: has_annotation,
+    ]
+}
+
+workflow PREPARE_GENOME_METADATA {
+
+    take:
+        input                   // channel: [ val(meta), path(query_json), path(genome_summary_json) ]
+
+    main:
+        channel_versions = Channel.empty()
+
+        METADATA_GENOMESUMMARY(input)
+            .meta_json
+            .map{ meta, json_file -> tuple(meta + metaFromGenomeJson(json_file), json_file) }
+            .set { genome_metadata }
+        
+        SCHEMA_JSON(genome_metadata)
+            .verified_json
+            .set { verified_genome_json }
+
+        channel_versions.mix(METADATA_GENOMESUMMARY.versions, SCHEMA_JSON.versions)
+
+    emit:
+        prepared_metadata = verified_genome_json // channel: [ val(meta), path(json) ]
+        versions = channel_versions      // channel: [ path(versions.yml), path(versions.yml) ]
+}
+

--- a/subworkflows/ensembl/prepare_genome_metadata/meta.yml
+++ b/subworkflows/ensembl/prepare_genome_metadata/meta.yml
@@ -14,7 +14,7 @@ components:
   - Ensembl/genomio:genome_metadata_prepare
   - Ensembl/genomio:schemas_json_validate
 input:
-  - ch_bam:
+  - input:
       type: map
       description: |
         Structured meta map, meta query JSON and NCBI datasets 'genome summary' JSON. 

--- a/subworkflows/ensembl/prepare_genome_metadata/meta.yml
+++ b/subworkflows/ensembl/prepare_genome_metadata/meta.yml
@@ -11,8 +11,8 @@ keywords:
   - utility
   - validation
 components:
-  - Ensembl/genomio:genome_metadata_prepare
-  - Ensembl/genomio:schemas_json_validate
+  - ensembl-genomio:genome_metadata_prepare
+  - ensembl-genomio:schemas_json_validate
 input:
   - input:
       type: map

--- a/subworkflows/ensembl/prepare_genome_metadata/meta.yml
+++ b/subworkflows/ensembl/prepare_genome_metadata/meta.yml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/subworkflows/yaml-schema.json
+name: "prepare_genome_metadata"
+description: A subworkflow to query specific genome metadata from a full genome summary report JSON \
+  obtained via NCBI datasets-cli.
+keywords:
+  - ensembl
+  - genome metadata
+  - genomio
+  - JSON
+  - metadata
+  - utility
+  - validation
+components:
+  - Ensembl/genomio:genome_metadata_prepare
+  - Ensembl/genomio:schemas_json_validate
+input:
+  - ch_bam:
+      type: map
+      description: |
+        Structured meta map, meta query JSON and NCBI datasets 'genome summary' JSON. 
+        Structure: [ val(meta), path(json) ]
+      pattern: "*.json"
+output:
+  - prepared_metadata:
+      type: map
+      description: |
+        Structured meta map and single schema verified genome meta JSON file.
+        Structure: [ val(meta), path(json) ]
+      pattern: "genome.json"
+  - versions:
+      type: file
+      description: |
+        File containing software versions
+        Structure: [ path(versions.yml) ]
+      pattern: "versions.yml"
+authors:
+  - "@ensembl-dev"
+maintainers:
+  - "@ensembl-dev"

--- a/subworkflows/ensembl/prepare_genome_metadata/tests/main.nf.test
+++ b/subworkflows/ensembl/prepare_genome_metadata/tests/main.nf.test
@@ -1,0 +1,45 @@
+// TODO nf-core: Once you have added the required tests, please run the following command to build this file:
+// nf-core subworkflows test prepare_genome_metadata
+nextflow_workflow {
+
+    name "Test Subworkflow PREPARE_GENOME_METADATA"
+    script "../main.nf"
+    workflow "PREPARE_GENOME_METADATA"
+
+    tag "subworkflows"
+    tag "subworkflows_ensembl"
+    tag "subworkflows/prepare_genome_metadata"
+    // TODO nf-core: Add tags for all modules used within this subworkflow. Example:
+    tag "samtools"
+    tag "samtools/sort"
+    tag "samtools/index"
+
+
+    // TODO nf-core: Change the test name preferably indicating the test-data and file-format used
+    test("sarscov2 - bam - single_end") {
+
+        when {
+            workflow {
+                """
+                // TODO nf-core: define inputs of the workflow here. Example:
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                ]
+                input[1] = [
+                    [ id:'genome' ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(workflow.out).match()}
+                //TODO nf-core: Add all required assertions to verify the test output.
+            )
+        }
+    }
+}

--- a/subworkflows/ensembl/prepare_genome_metadata/tests/main.nf.test
+++ b/subworkflows/ensembl/prepare_genome_metadata/tests/main.nf.test
@@ -8,10 +8,9 @@ nextflow_workflow {
     tag "subworkflows_ensembl"
     tag "subworkflows/prepare_genome_metadata"
 
-    test("genomesummary workflow test (with stub)") {
+    test("genomesummary workflow test (full test)") {
 
         when {
-            options "-stub"
 
             workflow {
                 """
@@ -35,7 +34,7 @@ nextflow_workflow {
                 { assert workflow.success},
                 { assert snapshot(workflow).match()},
                 { assert snapshot(workflow.out.versions) != null }
-                // { assert snapshot(workflow.out).size() == 2},
+
             )
         }
     }

--- a/subworkflows/ensembl/prepare_genome_metadata/tests/main.nf.test
+++ b/subworkflows/ensembl/prepare_genome_metadata/tests/main.nf.test
@@ -1,5 +1,3 @@
-// TODO nf-core: Once you have added the required tests, please run the following command to build this file:
-// nf-core subworkflows test prepare_genome_metadata
 nextflow_workflow {
 
     name "Test Subworkflow PREPARE_GENOME_METADATA"
@@ -28,17 +26,16 @@ nextflow_workflow {
 
             then {
                 assert snapshot(
-                    (workflow.out).prepared_metadata.collect {
+                    (workflow).out.prepared_metadata.collect {
                         it.collect { it instanceof String && file(it).exists() ? file(it).name : it }
                         }
                     ).match("genome.json")
 
             assertAll(
                 { assert workflow.success},
-                { assert snapshot(workflow.out).match()}
-                { assert snapshot(workflow.out).size() == 2}
-                { assert snapshot(workflow.out).prepared_metadata.size() == 1}
-                { assert snapshot(workflow.out).versions != null }
+                { assert snapshot(workflow).match()},
+                { assert snapshot(workflow.out.versions) != null }
+                // { assert snapshot(workflow.out).size() == 2},
             )
         }
     }

--- a/subworkflows/ensembl/prepare_genome_metadata/tests/main.nf.test
+++ b/subworkflows/ensembl/prepare_genome_metadata/tests/main.nf.test
@@ -9,36 +9,36 @@ nextflow_workflow {
     tag "subworkflows"
     tag "subworkflows_ensembl"
     tag "subworkflows/prepare_genome_metadata"
-    // TODO nf-core: Add tags for all modules used within this subworkflow. Example:
-    tag "samtools"
-    tag "samtools/sort"
-    tag "samtools/index"
 
-
-    // TODO nf-core: Change the test name preferably indicating the test-data and file-format used
-    test("sarscov2 - bam - single_end") {
+    test("genomesummary workflow test (with stub)") {
 
         when {
+            options "-stub"
+
             workflow {
                 """
-                // TODO nf-core: define inputs of the workflow here. Example:
                 input[0] = [
-                    [ id:'test', single_end:false ], // meta map
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
-                ]
-                input[1] = [
-                    [ id:'genome' ],
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
-                ]
+                    [accession: 'GCA_000001215.4'],
+                    file("${projectDir}/tests/modules/ensembl/metadata/genomesummary/meta-query.json", checkIfExists: true),
+                    file("${projectDir}/tests/modules/ensembl/metadata/genomesummary/ncbi_genome-summary.json", checkIfExists: true)
+                    ]
                 """
             }
         }
 
-        then {
+            then {
+                assert snapshot(
+                    (workflow.out).prepared_metadata.collect {
+                        it.collect { it instanceof String && file(it).exists() ? file(it).name : it }
+                        }
+                    ).match("genome.json")
+
             assertAll(
                 { assert workflow.success},
                 { assert snapshot(workflow.out).match()}
-                //TODO nf-core: Add all required assertions to verify the test output.
+                { assert snapshot(workflow.out).size() == 2}
+                { assert snapshot(workflow.out).prepared_metadata.size() == 1}
+                { assert snapshot(workflow.out).versions != null }
             )
         }
     }

--- a/subworkflows/ensembl/prepare_genome_metadata/tests/main.nf.test.snap
+++ b/subworkflows/ensembl/prepare_genome_metadata/tests/main.nf.test.snap
@@ -1,0 +1,85 @@
+{
+    "genomesummary workflow test (with stub)": {
+        "content": [
+            {
+                "stderr": [
+                    "\u001b[33mNextflow 24.10.5 is available - Please consider updating your version to it\u001b(B\u001b[m"
+                ],
+                "errorReport": null,
+                "exitStatus": 0,
+                "out": {
+                    "0": [
+                        [
+                            {
+                                "accession": "GCA_000001215.4",
+                                "production_name": "GCA_000001215.4",
+                                "publish_dir": "GCA_000001215.4",
+                                "prefix": "",
+                                "has_annotation": true
+                            },
+                            "genome.json:md5,35290e51b83617b0deb85f4da6fd0b51"
+                        ]
+                    ],
+                    "1": [
+                        "versions.yml:md5,889507ae0439c4584d12cf10d79e9202",
+                        "versions.yml:md5,9ce2ad4d825e8f06623e4d566fa7c6bc"
+                    ],
+                    "prepared_metadata": [
+                        [
+                            {
+                                "accession": "GCA_000001215.4",
+                                "production_name": "GCA_000001215.4",
+                                "publish_dir": "GCA_000001215.4",
+                                "prefix": "",
+                                "has_annotation": true
+                            },
+                            "genome.json:md5,35290e51b83617b0deb85f4da6fd0b51"
+                        ]
+                    ],
+                    "versions": [
+                        "versions.yml:md5,889507ae0439c4584d12cf10d79e9202",
+                        "versions.yml:md5,9ce2ad4d825e8f06623e4d566fa7c6bc"
+                    ]
+                },
+                "failed": false,
+                "stdout": [
+                    
+                ],
+                "errorMessage": null,
+                "trace": {
+                    "tasksFailed": 0,
+                    "tasksCount": 2,
+                    "tasksSucceeded": 2
+                },
+                "name": "workflow",
+                "success": true
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.3"
+        },
+        "timestamp": "2025-03-26T15:47:51.417603352"
+    },
+    "genome.json": {
+        "content": [
+            [
+                [
+                    {
+                        "accession": "GCA_000001215.4",
+                        "production_name": "GCA_000001215.4",
+                        "publish_dir": "GCA_000001215.4",
+                        "prefix": "",
+                        "has_annotation": true
+                    },
+                    "genome.json"
+                ]
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.3"
+        },
+        "timestamp": "2025-03-26T15:23:01.271023667"
+    }
+}

--- a/subworkflows/ensembl/prepare_genome_metadata/tests/main.nf.test.snap
+++ b/subworkflows/ensembl/prepare_genome_metadata/tests/main.nf.test.snap
@@ -1,5 +1,5 @@
 {
-    "genomesummary workflow test (with stub)": {
+    "genomesummary workflow test (full test)": {
         "content": [
             {
                 "stderr": [
@@ -17,7 +17,7 @@
                                 "prefix": "",
                                 "has_annotation": true
                             },
-                            "genome.json:md5,35290e51b83617b0deb85f4da6fd0b51"
+                            "genome.json:md5,9f34e758f4c9504a8f95476989af31c0"
                         ]
                     ],
                     "1": [
@@ -33,7 +33,7 @@
                                 "prefix": "",
                                 "has_annotation": true
                             },
-                            "genome.json:md5,35290e51b83617b0deb85f4da6fd0b51"
+                            "genome.json:md5,9f34e758f4c9504a8f95476989af31c0"
                         ]
                     ],
                     "versions": [
@@ -59,7 +59,7 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.3"
         },
-        "timestamp": "2025-03-26T15:47:51.417603352"
+        "timestamp": "2025-04-01T14:21:41.078165261"
     },
     "genome.json": {
         "content": [
@@ -80,6 +80,6 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.3"
         },
-        "timestamp": "2025-03-26T15:23:01.271023667"
+        "timestamp": "2025-04-01T15:09:04.471254559"
     }
 }


### PR DESCRIPTION
This work relates to the effort to convert a [module](https://github.com/Ensembl/ensembl-genomio/blob/main/pipelines/nextflow/modules/genome_metadata/prepare_genome_metadata.nf) (which essentially was structured as a subworkflow from ensmebl-genomio to nextflow_modules as a fully functional subworkflow. 

PR includes:

- [x] First working example of subworkflow added to nextflow_modules. 
- [x] Working Test and snapshot of the subworkflow.
- [x] Added second module (as a base minimum requirement for subworkflows) in the form of schema validation of the output genome.json

Note: this PR requires modules and test data related to [another PR](https://github.com/Ensembl/nextflow_modules/pull/23) 